### PR TITLE
Red Eyes & Invisible Walls

### DIFF
--- a/gamemodes/nzombies-unlimited/entities/entities/nzu_zombie_base.lua
+++ b/gamemodes/nzombies-unlimited/entities/entities/nzu_zombie_base.lua
@@ -917,7 +917,7 @@ if SERVER then
 
 	function ENT:RunBehaviour()
 		self:Retarget()
-		self:InitializePath()
+		if IsValid(self.Target) then self:InitializePath() end
 
 		while true do
 			if self.ActiveEvent then

--- a/gamemodes/nzombies-unlimited/gamemode/electricity.lua
+++ b/gamemodes/nzombies-unlimited/gamemode/electricity.lua
@@ -57,7 +57,7 @@ if SERVER then
 		net.Broadcast()
 
 		toggleelec()
-		hook.Run("nzu_OnElectricityTurnedOn")
+		hook.Run("nzu_OnElectricityOn")
 	end
 	
 	function nzu.TurnOffElectricity()
@@ -67,7 +67,7 @@ if SERVER then
 		net.Broadcast()
 
 		toggleelec()
-		hook.Run("nzu_OnElectricityTurnedOff")
+		hook.Run("nzu_OnElectricityOff")
 	end
 
 	-- Do electricity permanent if the map has no power switch
@@ -79,6 +79,7 @@ if SERVER then
 	hook.Add("nzu_GameStarted", "nzu_Electricity_AutoOn", function()
 		if not startoff then
 			nzu.TurnOnElectricity()
+		else
 			startoff = nil
 		end
 	end)

--- a/gamemodes/nzombies-unlimited/gamemode/menu/menu_configload.lua
+++ b/gamemodes/nzombies-unlimited/gamemode/menu/menu_configload.lua
@@ -4,7 +4,7 @@ Config Loading
 if CLIENT then
 	local configpaneltall = 60
 
-	nzu.AddMenuHook("LoadConfig", function(menu)
+	hook.Add("nzu_MenuCreated", "LoadConfig", function(menu)
 		local function doconfigclick(cfg)
 			if cfg then
 				net.Start("nzu_menu_loadconfigs")
@@ -18,6 +18,7 @@ if CLIENT then
 		local sub = menu:AddPanel("Load Config ...", 3, l)
 		l:Dock(FILL)
 		l:SetPaintBackground(true)
+		l:SetSelectable(true)
 
 		-- Access the config in Sandbox!
 		local sand = sub:GetTopBar():Add("DButton")
@@ -25,11 +26,11 @@ if CLIENT then
 		sand:SetText("Edit selected in Sandbox")
 		sand:SetWide(200)
 		sand:DockMargin(0,10,0,0)
-		sand:SetEnabled(menu.Config and true or false)
+		sand:SetEnabled(menu:GetConfig() and true or false)
 		sand.DoClick = function()
 			Derma_Query("Are you sure you want to change to SANDBOX?", "Mode change confirmation", "Change gamemode", function()
-				if menu.Config then
-					nzu.RequestEditConfig(menu.Config)
+				if menu:GetConfig() then
+					nzu.RequestEditConfig(menu:GetConfig())
 				end
 			end, "Cancel"):SetSkin("nZombies Unlimited")
 		end
@@ -41,6 +42,7 @@ if CLIENT then
 		
 		function sub:OnShown()
 			l:LoadConfigs()
+			l:SelectConfig(menu:GetConfig())
 		end
 		function sub:OnHid()
 			l:Clear()
@@ -56,6 +58,20 @@ if CLIENT then
 
 			menu:SetConfig(c)
 		end)
+
+		-- Add a function to the Ready Button to load the config
+		local function readybuttonload(self)
+			if menu:GetConfig() then
+				nzu.RequestLoadConfig(menu:GetConfig())
+			end
+		end
+
+		menu:AddReadyButtonFunction("Load Selected Config", 70, function()
+			if menu:GetConfig() then
+				local cfg = menu:GetConfig()
+				return not nzu.CurrentConfig or cfg.Codename ~= nzu.CurrentConfig.Codename or cfg.Type ~= nzu.CurrentConfig.Type
+			end
+		end, readybuttonload, true)
 
 	end)
 end

--- a/gamemodes/nzombies-unlimited/gamemode/menu/menu_customizeplayer.lua
+++ b/gamemodes/nzombies-unlimited/gamemode/menu/menu_customizeplayer.lua
@@ -2,7 +2,7 @@
 
 local default_animations = { "idle_all_01", "menu_walk" }
 
-nzu.AddMenuHook("CustomizePlayer", function(menu)
+hook.Add("nzu_MenuCreated", "CustomizePlayer", function(menu)
 	-- Player color and model menu
 	local sheet = vgui.Create( "DPropertySheet" )
 	sheet:Dock(FILL)

--- a/gamemodes/nzombies-unlimited/gamemode/menu/menu_mismatch.lua
+++ b/gamemodes/nzombies-unlimited/gamemode/menu/menu_mismatch.lua
@@ -2,7 +2,7 @@
 -- Make a button that opens the Mismatch panel
 -- But update the button so that it only appears when there is something to mismatch,
 -- as well as how many categories we have available
-nzu.AddMenuHook("Mismatch", function(menu)
+hook.Add("nzu_MenuCreated", "Mismatch", function(menu)
 	local sub,but = menu:AddSubMenu("Config Mismatch", 100, nil, true)
 	local mismatch = vgui.Create("nzu_MismatchPanel", sub)
 	sub:SetContents(mismatch) -- Kind of reversved order, but still works

--- a/gamemodes/nzombies-unlimited/gamemode/menu/scoreboard.lua
+++ b/gamemodes/nzombies-unlimited/gamemode/menu/scoreboard.lua
@@ -212,7 +212,7 @@ Game over sequence panel
 ---------------------------------------------------------------------------]]
 
 -- Global so extensions can replace it
-nzu.GameOverPanel = function()
+local gameoverpanelfunc = function()
 	local p = vgui.Create("Panel")
 	local txt = p:Add("DLabel")
 	txt:SetFont("nzu_Font_Bloody_Biggest")
@@ -240,7 +240,15 @@ end
 local gameoverpanel
 hook.Add("nzu_GameOverSequence", "nzu_Scoreboard_ShowOnGameOver", function(time)
 	if not LocalPlayer():IsUnspawned() then
-		local gp = gameoverpanel or nzu.GameOverPanel()
+		local gp = gameoverpanel
+		if not gp then
+			local hud = nzu.GetActiveHUD()
+			if hud and hud._GameOverPanel then
+				gp = hud:_GameOverPanel()
+			else
+				gp = gameoverpanelfunc()
+			end
+		end
 
 		show()
 
@@ -254,10 +262,18 @@ hook.Add("nzu_GameOverSequence", "nzu_Scoreboard_ShowOnGameOver", function(time)
 end)
 
 hook.Add("nzu_GameOver", "nzu_Scoreboard_ShowGameOverText", function(time)
-	if IsValid(gameoverpanel) then gameoverpanel:Remove() end
-	gameoverpanel = nzu.GameOverPanel()
+	if not LocalPlayer():IsUnspawned() then
+		if IsValid(gameoverpanel) then gameoverpanel:Remove() end
 
-	gameoverpanel:ParentToHUD()
-	gameoverpanel:SetPos(ScrW()/2 - gameoverpanel:GetWide()/2, ScrH()/2 - gameoverpanel:GetTall()/2)
-	gameoverpanel:SetVisible(true)
+		local hud = nzu.GetActiveHUD()
+		if hud and hud._GameOverPanel then -- Ask the HUD object to define a Game Over panel
+			gameoverpanel = hud:_GameOverPanel()
+		else
+			gameoverpanel = gameoverpanelfunc()
+		end
+
+		gameoverpanel:ParentToHUD()
+		gameoverpanel:SetPos(ScrW()/2 - gameoverpanel:GetWide()/2, ScrH()/2 - gameoverpanel:GetTall()/2)
+		gameoverpanel:SetVisible(true)
+	end
 end)

--- a/gamemodes/nzombies-unlimited/gamemode/round.lua
+++ b/gamemodes/nzombies-unlimited/gamemode/round.lua
@@ -47,8 +47,8 @@ if SERVER then
 	end)
 
 	ROUND.Zombies = ROUND.Zombies or {} -- List
-	ROUND.NumberZombies = 0 -- Count
-	ROUND.ZombiesToSpawn = 0 -- Zombies still not spawned
+	ROUND.NumberZombies = ROUND.NumberZombies or 0 -- Count
+	ROUND.ZombiesToSpawn = ROUND.ZombiesToSpawn or 0 -- Zombies still not spawned
 	function ROUND:GetRemainingZombies() return self.NumberZombies + self.ZombiesToSpawn end
 
 	local weightedrandom = nzu.WeightedRandom
@@ -87,6 +87,7 @@ if SERVER then
 			end
 		end
 	end
+	hook.Add("OnNPCKilled", "nzu_Round_ZombieDeath", dozombiedeath)
 	hook.Add("EntityRemoved", "nzu_Round_ZombieDeath", dozombiedeath)
 	--hook.Add("EntityRemoved", "nzu_Round_ZombieRemoved", dozombiedeath)
 
@@ -580,23 +581,4 @@ else
 			hook.Run("nzu_PlayerUnready", ply)
 		end
 	end)
-end
-
-
-if SERVER then
-	-- This is basically dropping out and being on the main menu
-	-- You can spectate from here too (later)
-	
-	function GM:PlayerInitialSpawn(ply)
-		-- Is this timer really necessary? :(
-		-- It doesn't seem to kill if not with the timer (probably cause it's before the spawn?)
-		timer.Simple(0, function()
-			if IsValid(ply) then
-				nzu.Unspawn(ply)
-				hook.Run("ShowHelp", ply) -- Open their F1 menu
-			end
-		end)
-	end
-
-	function GM:PlayerDeathThink() end
 end

--- a/gamemodes/nzombies-unlimited/gamemode/shared.lua
+++ b/gamemodes/nzombies-unlimited/gamemode/shared.lua
@@ -24,6 +24,7 @@ NZU_SANDBOX = false
 NZU_NZOMBIES = true
 
 loadfile_c("fonts.lua")
+loadfile("nzombies-unlimited/core/utils.lua")
 
 --[[-------------------------------------------------------------------------
 Extension Manager
@@ -77,6 +78,7 @@ loadfile_s("nzombies-unlimited/core/entities_tools/navlocker_nzu.lua")
 loadfile("nzombies-unlimited/core/entities_tools/barricades.lua")
 loadfile("nzombies-unlimited/core/entities_tools/wallbuys.lua")
 loadfile("nzombies-unlimited/core/entities_tools/invisiblewalls.lua")
+loadfile("nzombies-unlimited/core/entities_tools/naveditor.lua")
 
 --[[-------------------------------------------------------------------------
 Misc GM hooks

--- a/lua/nzombies-unlimited/core/config_panels.lua
+++ b/lua/nzombies-unlimited/core/config_panels.lua
@@ -1,5 +1,10 @@
-local PANEL = {}
 
+--[[-------------------------------------------------------------------------
+Config List panel [nzu_ConfigList]
+Child of ScrollPanel which can automatically list a set of [nzu_ConfigPanel]s
+---------------------------------------------------------------------------]]
+
+local PANEL = {}
 AccessorFunc(PANEL, "m_bAllowSelect", "Selectable", FORCE_BOOL)
 
 function PANEL:Init()
@@ -51,7 +56,7 @@ function PANEL:SetConfigPanelHeight(height)
 end
 
 function PANEL:SelectConfig(cfg)
-	if self.ConfigPanels[cfg] then
+	if cfg and self.ConfigPanels[cfg] then
 		if self.ConfigPanels[cfg] == self.SelectedPanel then return end
 
 		if IsValid(self.SelectedPanel) then self.SelectedPanel:SetSelected(false) end
@@ -149,7 +154,12 @@ end
 
 vgui.Register("nzu_ConfigList", PANEL, "DScrollPanel")
 
--- CONFIG PANEL
+
+
+--[[-------------------------------------------------------------------------
+Config Panel [nzu_ConfigPanel]
+A panel that shows a small clickable bar of a Config
+---------------------------------------------------------------------------]]
 local CONFIGPANEL = {}
 local emptyfunc = function() end
 function CONFIGPANEL:Init()
@@ -226,6 +236,7 @@ function CONFIGPANEL:SetConfig(config)
 	self:Update(config)
 	timer.Simple(0, function() hook.Add("nzu_ConfigInfoSaved", self, self.Update) end) -- Auto-update ourselves whenever updates arrive to this config
 end
+function CONFIGPANEL:GetConfig() return self.Config end
 
 function CONFIGPANEL:DoClick() end
 function CONFIGPANEL:DoRightClick() end
@@ -246,5 +257,91 @@ end
 local selectcol = Color(0,150,255)
 function CONFIGPANEL:SetSelected(b)
 	self:SetBackgroundColor(b and selectcol or nil)
+	self.Selected = b
 end
+function CONFIGPANEL:GetSelected() return self.Selected end
 vgui.Register("nzu_ConfigPanel", CONFIGPANEL, "DPanel")
+
+
+--[[-------------------------------------------------------------------------
+Config Image [nzu_ConfigImagePanel]
+A large showcase of a Config. Shows a big thumbnail with overlayed info
+This is what is used on the Main Menu
+---------------------------------------------------------------------------]]
+
+local MAPPANEL = {}
+AccessorFunc(MAPPANEL, "m_bAspectRatio", "MaintainAspectRatio", FORCE_BOOL)
+
+function MAPPANEL:Init()
+	self.InfoBar = self:Add("Panel")
+	self.InfoBar:Dock(BOTTOM)
+	self.InfoBar:SetTall(45)
+	function self.InfoBar.Paint(s)
+		surface.SetDrawColor(0,0,0,252)
+		s:DrawFilledRect()
+	end
+
+	local namemap = self.InfoBar:Add("Panel")
+	namemap:Dock(TOP)
+	namemap:SetTall(40)
+
+	self.Name = namemap:Add("DLabel")
+	self.Name:SetFont("Trebuchet24")
+	self.Name:SetTextColor(color_white)
+	self.Name:Dock(LEFT)
+	self.Name:DockMargin(5,0,5,10)
+
+	self.Map = namemap:Add("DLabel")
+	--self.Map:SetFont("Trebuchet24")
+	self.Map:SetTextColor(Color(200,200,200))
+	self.Map:Dock(LEFT)
+	self.Map:DockMargin(5,0,5,5)
+
+	self.Authors = self.InfoBar:Add("DLabel")
+	--self.Authors:SetFont("Trebuchet24")
+	self.Authors:SetTextColor(Color(150,150,150))
+	self.Authors:Dock(BOTTOM)
+	self.Authors:DockMargin(5,5,5,5)
+end
+
+AccessorFunc(MAPPANEL, "m_strNoConfigImage", "NoConfigImage", FORCE_STRING)
+AccessorFunc(MAPPANEL, "m_strNoConfigName", "NoConfigName", FORCE_STRING)
+AccessorFunc(MAPPANEL, "m_strNoConfigMap", "NoConfigMap", FORCE_STRING)
+AccessorFunc(MAPPANEL, "m_strNoConfigAuthors", "NoConfigAuthors", FORCE_STRING)
+function MAPPANEL:SetConfig(config)
+	self.Config = config
+	if config then
+		self:SetImage(nzu.GetConfigThumbnail(config))
+		self.Map:SetText(config.Map)
+		self.Map:SizeToContents()
+		self.Name:SetText(config.Name)
+		self.Name:SizeToContents()
+		self.Authors:SetText(config.Authors)
+		self.Authors:SizeToContents()			
+	else
+		self:SetImage(self:GetNoConfigImage() or "vgui/black")
+		self.Map:SetText(self:GetNoConfigMap() or "")
+		self.Map:SizeToContents()
+		self.Name:SetText(self:GetNoConfigName() or "No Config selected")
+		self.Name:SizeToContents()
+		self.Authors:SetText(self:GetNoConfigAuthors() or "")
+		self.Authors:SizeToContents()
+	end
+end
+
+function MAPPANEL:PerformLayout(w,h)
+	if self:GetMaintainAspectRatio() then
+		local d = self:GetDock()
+		if d == TOP or d == BOTTOM then
+			self:SetTall(w * 9/16)
+		elseif d == LEFT or d == RIGHT then
+			self:SetWide(h * 16/9)
+		end
+	end
+end
+
+function MAPPANEL:GetConfig()
+	return self.Config
+end
+
+vgui.Register("nzu_ConfigImagePanel", MAPPANEL, "DImage")

--- a/lua/nzombies-unlimited/core/entities_tools/barricades.lua
+++ b/lua/nzombies-unlimited/core/entities_tools/barricades.lua
@@ -77,6 +77,12 @@ function ENT:Initialize()
 
 		self:SetCanBeRepaired(false)
 		self:SetIsClear(self:GetPlankCount() == 0)
+
+		local phys = self:GetPhysicsObject()
+		if IsValid(phys) then
+			phys:EnableMotion(false)
+			phys:Sleep()
+		end
 	end
 
 	self:SetMaterial("models/wireframe")

--- a/lua/nzombies-unlimited/core/entities_tools/naveditor.lua
+++ b/lua/nzombies-unlimited/core/entities_tools/naveditor.lua
@@ -269,7 +269,6 @@ function TOOL:RightClick(trace)
 				self.LastActiveCommand = nil
 			end
 		else
-			print("Used side right")
 			self.LastSide = "right"
 		end
 		return result
@@ -352,7 +351,6 @@ if CLIENT then
 			self.LastStage = self:GetStage()
 			self.LastMarked = ismarked
 			self.ActiveSide = self:GetStage() > 0 and self.LastSide or nil
-			print(self.ActiveSide)
 		end
 		
 		local lmode = self:GetClientInfo("left")

--- a/lua/nzombies-unlimited/core/loader.lua
+++ b/lua/nzombies-unlimited/core/loader.lua
@@ -22,7 +22,7 @@ end
 --[[-------------------------------------------------------------------------
 Spawnmenu & Panels Preparation
 ---------------------------------------------------------------------------]]
---loadfile("utils.lua")
+loadfile("utils.lua")
 loadfile_c("cl_nzombies_skin.lua")
 loadfile_c("cl_spawnmenu.lua")
 loadfile("mismatch.lua")

--- a/lua/nzombies-unlimited/core/spawnmenu_saveload.lua
+++ b/lua/nzombies-unlimited/core/spawnmenu_saveload.lua
@@ -281,7 +281,7 @@ nzu.AddSpawnmenuTab("Save/Load", "DPanel", function(panel)
 	save:SetText("Save Config")
 
 	playbutton.DoClick = function(s)
-		local selectedconfig = configlist:GetSelectedConfig()
+		local selectedconfig = loadedcfg:IsSelected() and loadedcfg:GetConfig() or configlist:GetSelectedConfig()
 		if selectedconfig then
 			if selectedconfig == editedconfig then save:DoClick() end
 			Derma_Query("Do you wish to change gamemode to NZOMBIES UNLIMITED?", "Mode change confirmation", "Change gamemode", function()
@@ -377,7 +377,10 @@ nzu.AddSpawnmenuTab("Save/Load", "DPanel", function(panel)
 			playbutton:SetText("Load and Play")
 		end
 	end
-	configlist.OnConfigSelected = function(s,cfg,pnl) doconfigclick(pnl) end
+	configlist.OnConfigClicked = function(s,cfg,pnl)
+		loadedcfg:SetSelected(loadedcfg:GetConfig() == cfg)
+		doconfigclick(pnl)
+	end
 
 	-- Create new config button
 	createbutton:SetEnabled(nzu.IsAdmin(LocalPlayer()))
@@ -476,7 +479,11 @@ nzu.AddSpawnmenuTab("Save/Load", "DPanel", function(panel)
 
 		entry:RequestFocus()
 	end
-	loadedcfg.DoClick = doconfigclick
+	loadedcfg.DoClick = function(s)
+		configlist:SelectConfig(s:GetConfig()) -- Update the selected list
+		s:SetSelected(true)
+		doconfigclick(s)
+	end
 
 	local function applyinfo()
 		if editedconfig then

--- a/lua/nzombies-unlimited/core/sv_saveload.lua
+++ b/lua/nzombies-unlimited/core/sv_saveload.lua
@@ -23,8 +23,8 @@ function nzu.ReloadConfigMap(config)
 	local config = config or nzu.CurrentConfig
 	if not config then return end
 	
-	if not file.Exists(config.Path.."/config.dat", "GAME") then return end -- Not error, just load nothing
-	local str = file.Read(config.Path.."/config.dat", "GAME")
+	local str = file.Read(config.Path.."/config.dat", "GAME") or file.Read(config.Path.."/config.lua", "GAME")
+	if not str then return end -- Not error, just load nothing
 	
 	local startchar = string.find(str, '')
 	if startchar ~= nil then
@@ -41,7 +41,6 @@ function nzu.ReloadConfigMap(config)
 	local tab = util.JSONToTable(str)
 
 	game.CleanUpMap()
-
 	if not istable(tab) then
 		-- Error loading save!
 		print("nzu_saveload: Couldn't decode config save from JSON!")
@@ -688,7 +687,7 @@ Additional Config folder file read/write
 ---------------------------------------------------------------------------]]
 function nzu.WriteConfigFile(name, str)
 	if nzu.CurrentConfig and nzu.CurrentConfig.Type == "Local" then
-		file.Write("nzombies-unlimited/localconfigs/"..nzu.CurrentConfig.Codename.."/"..name, str)
+		file.Write("nzombies-unlimited/localconfigs/"..nzu.CurrentConfig.Codename.."/"..name..".txt", str)
 		return true
 	end
 	return false
@@ -696,7 +695,7 @@ end
 
 function nzu.ReadConfigFile(name)
 	if nzu.CurrentConfig then
-		return file.Read(nzu.CurrentConfig.Path.."/"..name, "GAME")
+		return file.Read(nzu.CurrentConfig.Path.."/"..name..".lua", "GAME") or file.Read(nzu.CurrentConfig.Path.."/"..name..".txt", "GAME")
 	end
 end
 
@@ -705,4 +704,6 @@ end
 -- Fixing up loading in nZombies
 if NZU_NZOMBIES then
 	duplicator.Allow("prop_physics")
+	duplicator.Allow("prop_physics_multiplayer")
+	duplicator.Allow("prop_effect")
 end

--- a/lua/nzombies-unlimited/huds/unlimited.lua
+++ b/lua/nzombies-unlimited/huds/unlimited.lua
@@ -687,3 +687,33 @@ function HUD:Draw_TargetID(text, typ, data, ent)
 		draw.SimpleText(str, targetidfont, x, y, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
 	end
 end
+
+--[[-------------------------------------------------------------------------
+Game Over Panel
+This is actually an internal function, but it is called through the Scoreboard file
+The _ prefix means it is ignored by the HUD system, and thus internal (or accessed directly)
+---------------------------------------------------------------------------]]
+function HUD:_GameOverPanel()
+	local p = vgui.Create("Panel")
+	local txt = p:Add("DLabel")
+	txt:SetFont("nzu_Font_Bloody_Biggest")
+	txt:SetTextColor(Color(150,0,0))
+	txt:SetText("GAME OVER")
+	txt:SetContentAlignment(5)
+	txt:Dock(FILL)
+	txt:DockMargin(0,0,0,-50)
+
+	local r = p:Add("DLabel")
+	r:SetFont("nzu_Font_Bloody_Large")
+	r:SetText(nzu.Round:GetRound() == 1 and "You survived 1 round." or "You survived "..(nzu.Round:GetRound() or 0).." rounds.")
+	r:SetTextColor(Color(150,0,0))
+	r:SetContentAlignment(5)
+	r:Dock(BOTTOM)
+	r:SizeToContentsY()
+	r:DockMargin(0,0,0,50)
+
+	p:SetTall(250)
+	p:SetWide(1000)
+
+	return p
+end


### PR DESCRIPTION
Update containing many minor and major bug fixes and improvements, as well as adding Red Eyes to the Zombies and fixing the Navmesh crash bug.

- Zombies now draw red eyes while alive
- Added ENT:Alive() to Zombie Base
- Updated Collision bounds of Zombie Base to fit that of the model, making players no longer get stuck in zombies
- Added ENT:Set/GetBlockAttack which prevents the zombie attacking
- Added ENT:GetTargetLocked which returns if the current target is locked
- Added ENT:DataTables() which can be overwritten to add more NetworkVars to subclass zombies
- Zombie Death Animations now overwrite any and all events instantly
- Removed ENT:PerformSpawn() and instead just used ENT:Event_Spawn()
- Fixed doors costing 0 with electricity requirement not opening when power is on
- Doors costing 0 without electricity requirement now open on game start
- Simplified the main menu's Ready button, adding Menu:AddReadyButtonFuunction which can set text, weight, a condition, and a click function for the button to determine
- Added Discord promo (though with no link yet) to the main menu too
- Menu can now be closed regardless of state if the player is not Unspawned
- nzu.AddMenuHook is now completely replaced by a simple hook.Add to the new hook "nzu_MenuCreated"
- Game Over panel is now overwritten through the HUD object in the function HUD:_GameOverPanel()
- Unspawn logic is now properly handled on player's initial spawn
- Player:IsUnspawned() now also returns true for Connecting players
- Zombies now also count as killed through the OnNPCKilled hook
- nzu_ConfigList:SelectConfig now deselects if nil is passed as argument
- Added nzu_ConfigImagePanel which is exactly what is on the main menu
- Barricades are now spawned frozen
- Entities can now have ENT.nzu_DoorHooked which means they can be shot by the Door tool, but the door itself is only opened through the group, not by E on itself
- Invisible Props now properly collide with players. Sadly, as of right now they are forced to also collide with Zombies
- Invisible Props can now be locked with the door tool, but are DoorHooked (cannot be opened by E, but opens with the Door Group)
- nzu.BuyDoor can now be called without a player, in which case the door is just opened for free, including its group
- Added net.ReadEntityQueued which can delay a function on a read entity until it becomes valid (useful on Client)
- Fixed door data not syncing to players spawning in after the load due to the lack of Queued reading on the entity networking
- Fixed Electricity Switch having stuttering physics
- Electricity Switch tool now auto-aligns the switch with the shot wall and the floor below (but can still be moved afterwards)
- Fixed Electricity Switch handle moving the wrong direction
- Electricity Switch handle now moves based on the entity's own Power, rather than global state
- Fixed Electricity Switch not drawing
- Worked around a crash bug when a Navmesh file attempted to connect two navmeshes that do not have a window between them (this is a gmod bug, this update just works around it)
- Corrected behavior of ID saving of re-creating a Config Navmesh file
- Config Navmesh file loading is now overwriting "navmesh.Load", meaning any call to that will load the Config's if it exists
- HUD object functions that begin with _ are now ignored completely by the handler
- Added support for HUD:OnDeployed() and HUD:OnUndeployed()
- HUD now properly disables and re-enables itself on localplayer Unspawn change
- HUD now properly starts disabled
- HUD now properly doesn't enable until LocalPlayer() is valid
- Changed Save/Load tab to work based on the Config List's selected config
- Fixed "Save and Play" not properly registering the selected config if it was just created without being clicked on
- nzu.WriteConfigFile and nzu.ReadConfigFile now no longer accept file extensions, and will always write .txt and always read .lua or .txt